### PR TITLE
feat: séparation leaderboard rngdle public + classement quotidien à minuit

### DIFF
--- a/alembic/versions/af8e3b2c1d5f_add_table_rngdleguildconfig.py
+++ b/alembic/versions/af8e3b2c1d5f_add_table_rngdleguildconfig.py
@@ -1,0 +1,31 @@
+"""Add rngdleguildconfig table
+
+Revision ID: 3752036c90fa
+Revises: 3752036c90fa
+Create Date: 2026-07-01 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "af8e3b2c1d5f"
+down_revision: Union[str, Sequence[str], None] = "3752036c90fa"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "rngdleguildconfig",
+        sa.Column("guild_id", sa.BigInteger(), nullable=False),
+        sa.Column("leaderboard_channel_id", sa.BigInteger(), nullable=True),
+        sa.PrimaryKeyConstraint("guild_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("rngdleguildconfig")

--- a/commands/cogs/rngdle.py
+++ b/commands/cogs/rngdle.py
@@ -1,20 +1,15 @@
-﻿from io import BytesIO
-
 import discord
 from discord import SlashCommandGroup
 from discord.ext import commands
 
 from config import MAGIC_COLOR
-from utils import get_or_fetch_user
-from utils.database.dao.rngdle import RNGdleDao
-from utils.image_generator import LeaderboardGenerator, LeaderboardUser
+from utils.database.dao.rngdle import RNGdleDao, RNGdleGuildConfigDao
 from utils.tasks.rngdle_sync import sync_guild_users
 
 
 class RNGdle(commands.Cog):
     def __init__(self, bot: discord.Bot):
         self.bot = bot
-        self.leaderboard_generator = LeaderboardGenerator()
 
     rng_group = SlashCommandGroup(name="rngdle", description="RNGDLE commands")
 
@@ -27,7 +22,7 @@ class RNGdle(commands.Cog):
         username: str,
     ) -> None:
         """Register an RNGDLE user."""
-        await ctx.defer()  # Defer the response to allow for longer processing time
+        await ctx.defer()
         await RNGdleDao.register_user(discord_user.id, ctx.guild.id, username)
         message = discord.Embed(
             title="RNGDLE user",
@@ -37,6 +32,7 @@ class RNGdle(commands.Cog):
         await ctx.respond(embed=message)
 
     @rng_group.command(description="Show registered RNGDLE users")
+    @discord.default_permissions()
     async def show(self, ctx: discord.ApplicationContext) -> None:
         """Show registered RNGDLE users."""
         await ctx.defer()
@@ -44,7 +40,6 @@ class RNGdle(commands.Cog):
             await ctx.respond("This command can only be used in a server!")
             return
 
-        await RNGdleDao.get_registered_users(ctx.guild.id)
         users = await RNGdleDao.get_registered_users(ctx.guild.id)
         if not users:
             await ctx.respond("No registered RNGDLE users found.")
@@ -60,43 +55,30 @@ class RNGdle(commands.Cog):
         )
         await ctx.respond(embed=message)
 
-    @rng_group.command(description="Show RNGDLE leaderboard")
-    async def leaderboard(self, ctx: discord.ApplicationContext) -> None:
-        """Show RNGDLE leaderboard."""
+    @rng_group.command(
+        description="Set the channel for daily RNGDLE leaderboard"
+    )
+    @discord.default_permissions()
+    async def setleaderboard(
+        self,
+        ctx: discord.ApplicationContext,
+        channel: discord.TextChannel,
+    ) -> None:
+        """Set the channel where the daily leaderboard will be posted at midnight."""
         await ctx.defer()
         if ctx.guild is None:
             await ctx.respond("This command can only be used in a server!")
-
-        scores = await RNGdleDao.get_today_scores(ctx.guild.id)
-        if not scores:
-            await ctx.respond("No today scores found.")
             return
 
-        users: list[discord.User] = []
-        for score in scores:
-            user = await get_or_fetch_user(self.bot, score.user_id)
-            if user is not None:
-                users.append(user)
-
-        leaderboard_user: list[LeaderboardUser] = []
-        for user, score, rank in zip(users, scores, range(len(users))):
-            user_ = LeaderboardUser()
-            user_.user = user
-            user_.score = f"{score.score}({score.number})"
-            user_.rank = rank + 1  # Rank starts from 1
-            leaderboard_user.append(user_)
-
-        generated_leaderboard = (
-            await self.leaderboard_generator.generate_leaderboard(
-                leaderboard_user, 200
-            )
+        await RNGdleGuildConfigDao.set_leaderboard_channel(
+            ctx.guild.id, channel.id
         )
-        buffer = BytesIO()
-        generated_leaderboard.save(buffer, format="PNG")
-        buffer.seek(0)  # Move to the beginning of the BytesIO buffer
-        file = discord.File(fp=buffer, filename="leaderboard.png")
-
-        await ctx.respond(file=file)
+        message = discord.Embed(
+            title="RNGdle Leaderboard Channel",
+            color=discord.Colour(MAGIC_COLOR),
+            description=f"Daily leaderboard will be posted in {channel.mention}.",
+        )
+        await ctx.respond(embed=message)
 
     @rng_group.command(description="Manually refresh RNGdle scores for all registered users")
     @discord.default_permissions()

--- a/commands/cogs/rngdle_leaderboard.py
+++ b/commands/cogs/rngdle_leaderboard.py
@@ -1,0 +1,63 @@
+from io import BytesIO
+
+import discord
+from discord.ext import commands
+
+from config import MAGIC_COLOR
+from utils import get_or_fetch_user
+from utils.database.dao.rngdle import RNGdleDao
+from utils.image_generator import LeaderboardGenerator, LeaderboardUser
+
+
+class RNGdleLeaderboard(commands.Cog):
+    def __init__(self, bot: discord.Bot):
+        self.bot = bot
+        self.leaderboard_generator = LeaderboardGenerator()
+
+    @commands.slash_command(
+        name="rngdle-leaderboard",
+        description="Show RNGDLE leaderboard",
+    )
+    async def rngdle_leaderboard(
+        self, ctx: discord.ApplicationContext
+    ) -> None:
+        """Show RNGDLE leaderboard."""
+        await ctx.defer()
+        if ctx.guild is None:
+            await ctx.respond("This command can only be used in a server!")
+            return
+
+        scores = await RNGdleDao.get_today_scores(ctx.guild.id)
+        if not scores:
+            await ctx.respond("No today scores found.")
+            return
+
+        users: list[discord.User] = []
+        for score in scores:
+            user = await get_or_fetch_user(self.bot, score.user_id)
+            if user is not None:
+                users.append(user)
+
+        leaderboard_user: list[LeaderboardUser] = []
+        for user, score, rank in zip(users, scores, range(len(users))):
+            user_ = LeaderboardUser()
+            user_.user = user
+            user_.score = f"{score.score}({score.number})"
+            user_.rank = rank + 1
+            leaderboard_user.append(user_)
+
+        generated_leaderboard = (
+            await self.leaderboard_generator.generate_leaderboard(
+                leaderboard_user, 200
+            )
+        )
+        buffer = BytesIO()
+        generated_leaderboard.save(buffer, format="PNG")
+        buffer.seek(0)
+        file = discord.File(fp=buffer, filename="leaderboard.png")
+
+        await ctx.respond(file=file)
+
+
+def setup(bot):
+    bot.add_cog(RNGdleLeaderboard(bot))

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import discord
 
 from config import BOT_TOKEN, DEBUG_GUILD_ID, LOGGER, setup_logging
 from utils.database import init_db
+from utils.tasks.rngdle_daily_leaderboard import schedule_rngdle_daily_leaderboard
 from utils.tasks.rngdle_sync import schedule_rngdle_sync
 
 
@@ -23,6 +24,8 @@ async def on_ready():
     LOGGER.info("------")
     # Schedule the hourly RNGdle sync task
     schedule_rngdle_sync(bot)
+    # Schedule the daily RNGdle leaderboard task (midnight UTC)
+    schedule_rngdle_daily_leaderboard(bot)
 
 
 bot.load_extensions("commands", recursive=True)

--- a/utils/database/dao/rngdle.py
+++ b/utils/database/dao/rngdle.py
@@ -1,9 +1,9 @@
-﻿from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Sequence
 
 from sqlalchemy.sql.expression import select
 
-from utils.database import RNGdle, RNGdleUser, get_db
+from utils.database import RNGdle, RNGdleGuildConfig, RNGdleUser, get_db
 
 
 def get_today_range():
@@ -13,6 +13,16 @@ def get_today_range():
 
     start_ts = int(start_of_day.timestamp()) * 1000
     end_ts = int(start_of_next_day.timestamp()) * 1000
+    return start_ts, end_ts
+
+
+def get_yesterday_range():
+    now = datetime.now(timezone.utc)
+    start_of_today = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    start_of_yesterday = start_of_today - timedelta(days=1)
+
+    start_ts = int(start_of_yesterday.timestamp()) * 1000
+    end_ts = int(start_of_today.timestamp()) * 1000
     return start_ts, end_ts
 
 
@@ -123,3 +133,63 @@ class RNGdleDao:
             return rows.scalars().all()
 
         return None
+
+    @staticmethod
+    async def get_scores_in_range(
+        guild_id: int, start_ts: int, end_ts: int
+    ) -> Sequence[RNGdle] | None:
+        async for session in get_db():
+            query = (
+                select(RNGdle)
+                .filter(
+                    RNGdle.guild_id == guild_id,
+                    RNGdle.date >= start_ts,
+                    RNGdle.date < end_ts,
+                )
+                .order_by(RNGdle.score.desc())
+            )
+
+            rows = await session.execute(query)
+            return rows.scalars().all()
+
+        return None
+
+
+class RNGdleGuildConfigDao:
+
+    @staticmethod
+    async def set_leaderboard_channel(guild_id: int, channel_id: int | None) -> None:
+        async for session in get_db():
+            existing = await session.execute(
+                select(RNGdleGuildConfig).filter(RNGdleGuildConfig.guild_id == guild_id)
+            )
+            config = existing.scalars().first()
+
+            if config is not None:
+                config.leaderboard_channel_id = channel_id
+                session.add(config)
+            else:
+                config = RNGdleGuildConfig(
+                    guild_id=guild_id, leaderboard_channel_id=channel_id
+                )
+                session.add(config)
+
+            await session.commit()
+
+    @staticmethod
+    async def get_leaderboard_channel(guild_id: int) -> int | None:
+        async for session in get_db():
+            existing = await session.execute(
+                select(RNGdleGuildConfig).filter(RNGdleGuildConfig.guild_id == guild_id)
+            )
+            config = existing.scalars().first()
+            if config is not None:
+                return config.leaderboard_channel_id
+            return None
+
+    @staticmethod
+    async def get_all_configured_guilds() -> Sequence[RNGdleGuildConfig]:
+        async for session in get_db():
+            result = await session.execute(select(RNGdleGuildConfig))
+            return result.scalars().all()
+        return []

--- a/utils/database/schema.py
+++ b/utils/database/schema.py
@@ -46,3 +46,10 @@ class RNGdleUser(Base):
     user_id = Column(BigInteger, primary_key=True, nullable=False)
     guild_id = Column(BigInteger, nullable=False)
     rng_username = Column(Text, nullable=False)
+
+
+class RNGdleGuildConfig(Base):
+    __tablename__ = "rngdleguildconfig"
+
+    guild_id = Column(BigInteger, primary_key=True, nullable=False)
+    leaderboard_channel_id = Column(BigInteger, nullable=True)

--- a/utils/tasks/rngdle_daily_leaderboard.py
+++ b/utils/tasks/rngdle_daily_leaderboard.py
@@ -1,0 +1,100 @@
+import asyncio
+from datetime import datetime, timedelta, timezone
+from io import BytesIO
+
+import discord
+
+from config import LOGGER
+from utils import get_or_fetch_user
+from utils.database.dao.rngdle import RNGdleDao, RNGdleGuildConfigDao, get_yesterday_range
+from utils.image_generator import LeaderboardGenerator, LeaderboardUser
+
+
+async def send_daily_leaderboard(bot: discord.Bot) -> None:
+    configs = await RNGdleGuildConfigDao.get_all_configured_guilds()
+
+    for config in configs:
+        if config.leaderboard_channel_id is None:
+            continue
+
+        guild = bot.get_guild(config.guild_id)
+        if guild is None:
+            continue
+
+        channel = guild.get_channel(config.leaderboard_channel_id)
+        if channel is None or not isinstance(channel, discord.TextChannel):
+            continue
+
+        start_ts, end_ts = get_yesterday_range()
+        scores = await RNGdleDao.get_scores_in_range(config.guild_id, start_ts, end_ts)
+
+        if not scores:
+            continue
+
+        users: list[discord.User] = []
+        for score in scores:
+            user = await get_or_fetch_user(bot, score.user_id)
+            if user is not None:
+                users.append(user)
+
+        if not users:
+            continue
+
+        generator = LeaderboardGenerator()
+        leaderboard_users: list[LeaderboardUser] = []
+        for user, score, rank in zip(users, scores, range(len(users))):
+            u = LeaderboardUser()
+            u.user = user
+            u.score = f"{score.score}({score.number})"
+            u.rank = rank + 1
+            leaderboard_users.append(u)
+
+        generated = await generator.generate_leaderboard(leaderboard_users, 200)
+        buffer = BytesIO()
+        generated.save(buffer, format="PNG")
+        buffer.seek(0)
+        file = discord.File(fp=buffer, filename="leaderboard.png")
+
+        top_score = scores[0].score
+        top_users = [
+            users[i]
+            for i, score in enumerate(scores)
+            if score.score == top_score
+        ]
+        mentions = " ".join(u.mention for u in top_users)
+
+        await channel.send(
+            content=f"🏆 Daily RNGDLE leaderboard — Félicitations à {mentions} !",
+            file=file,
+        )
+
+        LOGGER.info(
+            f"Daily leaderboard sent to guild {config.guild_id} ({channel.name})"
+        )
+
+
+async def rngdle_daily_leaderboard_loop(bot: discord.Bot) -> None:
+    while True:
+        now = datetime.now(timezone.utc)
+        next_midnight = (now + timedelta(days=1)).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+        sleep_seconds = (next_midnight - now).total_seconds()
+
+        LOGGER.info(
+            f"Daily leaderboard task: sleeping {sleep_seconds:.0f}s until midnight UTC"
+        )
+        await asyncio.sleep(sleep_seconds)
+
+        try:
+            await send_daily_leaderboard(bot)
+        except Exception:
+            LOGGER.exception("Failed to send daily leaderboard")
+
+
+def schedule_rngdle_daily_leaderboard(bot: discord.Bot) -> None:
+    try:
+        bot.loop.create_task(rngdle_daily_leaderboard_loop(bot))
+        LOGGER.info("RNGdle daily leaderboard task scheduled")
+    except Exception:
+        LOGGER.exception("Failed to schedule RNGdle daily leaderboard")


### PR DESCRIPTION
## Changements

### Leaderboard public
- Nouvelle commande standalone `/rngdle-leaderboard` accessible à tous les utilisateurs
- Le groupe `/rngdle` passe entièrement en admin-only (`register`, `show`, `setleaderboard`, `refresh`)

### Classement quotidien automatique
- Nouvelle commande admin `/rngdle setleaderboard <channel>` pour configurer le salon
- Tous les jours à 00:00 UTC, envoie le leaderboard du jour précédent dans le salon configuré
- Ping de tous les utilisateurs ex-aequo à la première place

### Base de données
- Nouvelle table `rngdleguildconfig` (guild_id, leaderboard_channel_id)
- Migration Alembic incluse

### Technique
- Nouveau cog: `commands/cogs/rngdle_leaderboard.py`
- Nouvelle tâche planifiée: `utils/tasks/rngdle_daily_leaderboard.py`
- Nouveau DAO: `RNGdleGuildConfigDao`