### PR TITLE
refactor: remplacer les boucles asyncio par discord.ext.tasks

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,8 +2,8 @@ import discord
 
 from config import BOT_TOKEN, DEBUG_GUILD_ID, LOGGER, setup_logging
 from utils.database import init_db
-from utils.tasks.rngdle_daily_leaderboard import schedule_rngdle_daily_leaderboard
-from utils.tasks.rngdle_sync import schedule_rngdle_sync
+from utils.tasks.rngdle_daily_leaderboard import rngdle_daily_leaderboard_task
+from utils.tasks.rngdle_sync import rngdle_sync_task
 
 
 setup_logging()
@@ -22,10 +22,18 @@ async def on_ready():
     await init_db()
     LOGGER.info("Database initialized successfully.")
     LOGGER.info("------")
-    # Schedule the hourly RNGdle sync task
-    schedule_rngdle_sync(bot)
-    # Schedule the daily RNGdle leaderboard task (midnight UTC)
-    schedule_rngdle_daily_leaderboard(bot)
+
+    if not rngdle_sync_task.is_running():
+        rngdle_sync_task.start()
+        LOGGER.info("RNGdle sync task started")
+    else:
+        LOGGER.info("RNGdle sync task already running")
+
+    if not rngdle_daily_leaderboard_task.is_running():
+        rngdle_daily_leaderboard_task.start(bot)
+        LOGGER.info("RNGdle daily leaderboard task started")
+    else:
+        LOGGER.info("RNGdle daily leaderboard task already running")
 
 
 bot.load_extensions("commands", recursive=True)

--- a/utils/tasks/rngdle_daily_leaderboard.py
+++ b/utils/tasks/rngdle_daily_leaderboard.py
@@ -1,8 +1,8 @@
-import asyncio
-from datetime import datetime, timedelta, timezone
+from datetime import time, timezone
 from io import BytesIO
 
 import discord
+from discord.ext import tasks
 
 from config import LOGGER
 from utils import get_or_fetch_user
@@ -10,7 +10,8 @@ from utils.database.dao.rngdle import RNGdleDao, RNGdleGuildConfigDao, get_yeste
 from utils.image_generator import LeaderboardGenerator, LeaderboardUser
 
 
-async def send_daily_leaderboard(bot: discord.Bot) -> None:
+@tasks.loop(time=time(hour=0, minute=0, tzinfo=timezone.utc))
+async def rngdle_daily_leaderboard_task(bot: discord.Bot) -> None:
     configs = await RNGdleGuildConfigDao.get_all_configured_guilds()
 
     for config in configs:
@@ -73,28 +74,6 @@ async def send_daily_leaderboard(bot: discord.Bot) -> None:
         )
 
 
-async def rngdle_daily_leaderboard_loop(bot: discord.Bot) -> None:
-    while True:
-        now = datetime.now(timezone.utc)
-        next_midnight = (now + timedelta(days=1)).replace(
-            hour=0, minute=0, second=0, microsecond=0
-        )
-        sleep_seconds = (next_midnight - now).total_seconds()
-
-        LOGGER.info(
-            f"Daily leaderboard task: sleeping {sleep_seconds:.0f}s until midnight UTC"
-        )
-        await asyncio.sleep(sleep_seconds)
-
-        try:
-            await send_daily_leaderboard(bot)
-        except Exception:
-            LOGGER.exception("Failed to send daily leaderboard")
-
-
-def schedule_rngdle_daily_leaderboard(bot: discord.Bot) -> None:
-    try:
-        bot.loop.create_task(rngdle_daily_leaderboard_loop(bot))
-        LOGGER.info("RNGdle daily leaderboard task scheduled")
-    except Exception:
-        LOGGER.exception("Failed to schedule RNGdle daily leaderboard")
+@rngdle_daily_leaderboard_task.error
+async def on_daily_leaderboard_error(exc: Exception) -> None:
+    LOGGER.error(f"Daily leaderboard task error: {exc}")

--- a/utils/tasks/rngdle_sync.py
+++ b/utils/tasks/rngdle_sync.py
@@ -1,5 +1,6 @@
-import asyncio
 import traceback
+
+from discord.ext import tasks
 
 from config import LOGGER, RNGDLE_SYNC_INTERVAL
 from utils.database.dao.rngdle import RNGdleDao
@@ -27,7 +28,6 @@ async def _process_user(rng_client: RNGdleClient, db_user, log_mode: str = "back
             LOGGER.debug(f"No rolls found for {db_user.rng_username}")
             return {"processed": 0, "failed": 0}
 
-        # rolls is a list of UserRolls objects, store each (upsert will ignore older ones)
         for roll in rolls:
             try:
                 inserted = await RNGdleDao.upsert_rngdle(
@@ -57,26 +57,24 @@ async def _process_user(rng_client: RNGdleClient, db_user, log_mode: str = "back
     return {"processed": processed, "failed": failed}
 
 
-async def rngdle_sync_loop():
-    """Main loop: every hour fetch all registered users and sync their rolls."""
+@tasks.loop(seconds=RNGDLE_SYNC_INTERVAL)
+async def rngdle_sync_task() -> None:
+    """Every hour fetch all registered users and sync their rolls."""
     rng_client = RNGdleClient()
-    while True:
-        try:
-            LOGGER.info("RNGdle sync: starting pass to fetch registered users")
-            users = await RNGdleDao.get_all_registered_users()
-            if not users:
-                LOGGER.info("RNGdle sync: no registered users found")
-            else:
-                for user in users:
-                    await _process_user(rng_client, user, log_mode="background")
+    LOGGER.info("RNGdle sync: starting pass to fetch registered users")
+    users = await RNGdleDao.get_all_registered_users()
+    if not users:
+        LOGGER.info("RNGdle sync: no registered users found")
+    else:
+        for user in users:
+            await _process_user(rng_client, user, log_mode="background")
 
-            LOGGER.info(
-                f"RNGdle sync: pass complete, sleeping {RNGDLE_SYNC_INTERVAL} seconds"
-            )
-        except Exception:
-            LOGGER.error(f"RNGdle sync loop error: {traceback.format_exc()}")
+    LOGGER.info(f"RNGdle sync: pass complete")
 
-        await asyncio.sleep(RNGDLE_SYNC_INTERVAL)
+
+@rngdle_sync_task.error
+async def on_rngdle_sync_error(exc: Exception) -> None:
+    LOGGER.error(f"RNGdle sync task error: {exc}")
 
 
 async def sync_guild_users(guild_id: int) -> dict:
@@ -99,14 +97,3 @@ async def sync_guild_users(guild_id: int) -> dict:
         total_failed += stats["failed"]
 
     return {"processed": total_processed, "failed": total_failed, "users_count": len(users)}
-
-
-def schedule_rngdle_sync(bot) -> None:
-    """Schedule the background sync loop on the bot event loop."""
-    try:
-        bot.loop.create_task(rngdle_sync_loop())
-        LOGGER.info("RNGdle background sync scheduled")
-    except Exception:
-        LOGGER.error(
-            f"Failed to schedule rngdle sync: {traceback.format_exc()}"
-        )


### PR DESCRIPTION
## Changements

Remplacement des boucles `while True` + `asyncio.sleep()` par les décorateurs `@tasks.loop` de py-cord.

### `rngdle_sync.py`
- `rngdle_sync_loop()` → `@tasks.loop(seconds=RNGDLE_SYNC_INTERVAL)`
- `schedule_rngdle_sync()` supprimée

### `rngdle_daily_leaderboard.py`
- `rngdle_daily_leaderboard_loop()` + calcul manuel du minuit → `@tasks.loop(time=time(hour=0, minute=0, tzinfo=timezone.utc))`
- `schedule_rngdle_daily_leaderboard()` supprimée

### `main.py`
- Import direct des `Loop` objects
- `.start()` avec `is_running()` dans `on_ready`