### PR TITLE
ci: build & push docker image sur tag

### DIFF
--- a/.github/workflows/docker-tag-push.yml
+++ b/.github/workflows/docker-tag-push.yml
@@ -1,0 +1,52 @@
+name: Build and push Docker image
+
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Crée un workflow GitHub Actions qui build et push l'image Docker sur `ghcr.io` automatiquement quand un tag `v*` est créé.

**Déploiement :**
```bash
git tag v1.0.0  # ou v2.1.3, etc.
git push origin v1.0.0
```
Le workflow :
1. Login à ghcr via `GITHUB_TOKEN`
2. Build l'image avec Docker Buildx
3. Push les tags : `v1.0.0`, `v1.0`, `latest`

**En prod :** il suffit de pull et redémarrer :
```bash
docker compose -f compose-prod.yml pull && docker compose -f compose-prod.yml up -d
```