### PR TITLE
fix: text always fits in leaderboard columns (font sizing)

### DIFF
--- a/commands/cogs/rngdle_leaderboard.py
+++ b/commands/cogs/rngdle_leaderboard.py
@@ -7,6 +7,7 @@ from config import MAGIC_COLOR
 from utils import get_or_fetch_user
 from utils.database.dao.rngdle import RNGdleDao
 from utils.image_generator import LeaderboardGenerator, LeaderboardUser
+from utils.number_utils import format_number
 
 
 class RNGdleLeaderboard(commands.Cog):
@@ -42,7 +43,7 @@ class RNGdleLeaderboard(commands.Cog):
         for user, score, rank in zip(users, scores, range(len(users))):
             user_ = LeaderboardUser()
             user_.user = user
-            user_.score = str(score.score)
+            user_.score = format_number(score.score)
             user_.tirage = str(score.number)
             user_.rank = rank + 1
             leaderboard_user.append(user_)

--- a/utils/image_generator.py
+++ b/utils/image_generator.py
@@ -31,9 +31,7 @@ class LeaderboardGenerator:
     HIGHLIGHT_COLOR = (0, 100, 200)  # For "async" button
 
     def __init__(self):
-        """
-        Initializes the Leaderboard Generator.
-        """
+        self.font_path = None
         self.base_path = (
             f"{pathlib.Path(__file__).parent.resolve()}/../ressources"
         )
@@ -57,23 +55,27 @@ class LeaderboardGenerator:
         )
 
         try:
-            # Attempt to load a specific font, fallback to default if not found or no path provided
-            self.font_header = ImageFont.truetype(
-                f"{self.base_path}/font/outfit.ttf", 40
-            )
-            self.font_regular = ImageFont.truetype(
-                f"{self.base_path}/font/outfit.ttf", 30
-            )
-            self.font_small = ImageFont.truetype(
-                f"{self.base_path}/font/outfit.ttf", 24
-            )
+            self.font_path = f"{self.base_path}/font/outfit.ttf"
+            self.font_header = ImageFont.truetype(self.font_path, 40)
+            self.font_regular = ImageFont.truetype(self.font_path, 30)
+            self.font_small = ImageFont.truetype(self.font_path, 24)
         except IOError:
             LOGGER.warning(
                 "Warning: Could not load specified font. Using Pillow's default font."
             )
+            self.font_path = None
             self.font_header = ImageFont.load_default()
             self.font_regular = ImageFont.load_default()
             self.font_small = ImageFont.load_default()
+
+    def _draw_fitted(self, draw, text, x, y, max_width, base_font, fill):
+        if self.font_path is None:
+            draw.text((x, y), text, fill=fill, font=base_font)
+            return
+        font = base_font
+        while draw.textlength(text, font=font) > max_width and font.size > 1:
+            font = ImageFont.truetype(self.font_path, font.size - 1)
+        draw.text((x, y), text, fill=fill, font=font)
 
     async def generate_leaderboard(self, users: list[LeaderboardUser]):
         total_height = self.HEADER_HEIGHT + (len(users) * self.ROW_HEIGHT)
@@ -181,11 +183,14 @@ class LeaderboardGenerator:
 
             username_x = 190
             username_y = y_pos + (self.ROW_HEIGHT / 2) - 15
-            draw.text(
-                (username_x, username_y),
+            self._draw_fitted(
+                draw,
                 user.user.name,
-                fill=self.TEXT_COLOR,
-                font=self.font_regular,
+                username_x,
+                username_y,
+                320,
+                self.font_regular,
+                self.TEXT_COLOR,
             )
 
             tirage_x = x_offsets[2]
@@ -199,11 +204,14 @@ class LeaderboardGenerator:
 
             score_x = x_offsets[3]
             score_y = y_pos + (self.ROW_HEIGHT / 2) - 15
-            draw.text(
-                (score_x, score_y),
+            self._draw_fitted(
+                draw,
                 user.score,
-                fill=self.TEXT_COLOR,
-                font=self.font_regular,
+                score_x,
+                score_y,
+                140,
+                self.font_regular,
+                self.TEXT_COLOR,
             )
 
         return img

--- a/utils/number_utils.py
+++ b/utils/number_utils.py
@@ -1,0 +1,9 @@
+def format_number(n: int) -> str:
+    if n >= 1_000_000_000:
+        return f"{n / 1_000_000_000:.1f}B"
+    elif n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    elif n >= 1_000:
+        return f"{n / 1_000:.1f}k"
+    else:
+        return str(n)

--- a/utils/tasks/rngdle_daily_leaderboard.py
+++ b/utils/tasks/rngdle_daily_leaderboard.py
@@ -8,6 +8,7 @@ from config import LOGGER
 from utils import get_or_fetch_user
 from utils.database.dao.rngdle import RNGdleDao, RNGdleGuildConfigDao, get_yesterday_range
 from utils.image_generator import LeaderboardGenerator, LeaderboardUser
+from utils.number_utils import format_number
 
 
 @tasks.loop(time=time(hour=0, minute=0, tzinfo=timezone.utc))
@@ -46,7 +47,7 @@ async def rngdle_daily_leaderboard_task(bot: discord.Bot) -> None:
         for user, score, rank in zip(users, scores, range(len(users))):
             u = LeaderboardUser()
             u.user = user
-            u.score = str(score.score)
+            u.score = format_number(score.score)
             u.tirage = str(score.number)
             u.rank = rank + 1
             leaderboard_users.append(u)


### PR DESCRIPTION
Adapte en Python/Pillow la logique `withComputedFontSize` du projet AsyncLevelling.

**`utils/number_utils.py`** (nouveau)
- `format_number` : abrège les grands nombres (1.2k, 3.5M, 1.8B)

**`utils/image_generator.py`**
- Nouvelle méthode `_draw_fitted(draw, text, x, y, max_width, base_font, fill)`
- Mesure la vraie largeur du texte avec `draw.textlength()`
- Réduit la taille de la police jusqu'à ce que ça tienne dans max_width
- Appliqué sur la colonne **Pseudo** (max 320px) et **Score** (max 140px)
- `font_path` stocké pour recréer la police à différentes tailles

**`rngdle_leaderboard.py` / `rngdle_daily_leaderboard.py`**
- Score formaté avec `format_number` avant affichage