### PR TITLE
fix: LeaderboardUser.tirage default + séparation jd4h leaderboard

### DIFF
--- a/commands/cogs/game.py
+++ b/commands/cogs/game.py
@@ -1,21 +1,8 @@
-from io import BytesIO
-
 import discord
 from discord import SlashCommandGroup
 from discord.ext import commands
 
 from config import LOGGER, MAGIC_COLOR
-from utils import get_or_fetch_user
-from utils.database import User
-from utils.database.dao.users import UserDao
-from utils.image_generator import LeaderboardGenerator, LeaderboardUser
-
-
-def get_medal_emoji(position: int) -> str:
-    """Get the medal emoji based on the user's position."""
-    icons: dict[int, str] = {1: "🥇", 2: "🥈", 3: "🥉"}
-
-    return icons.get(position, f"#{position}")
 
 
 class Game(commands.Cog):
@@ -23,48 +10,10 @@ class Game(commands.Cog):
 
     def __init__(self, bot: discord.Bot):
         self.bot = bot
-        self.leaderboard_generator = LeaderboardGenerator()
 
     jd4h = SlashCommandGroup(
         name="jd4h", description="Commands for the 4h game"
     )
-
-    async def get_user_data(self, users: list[type[User]]):
-        users_response = []
-        for user in users:
-            user_data = await get_or_fetch_user(self.bot, user.user_id)
-            if user_data:
-                user_ = LeaderboardUser()
-                user_.user = user_data
-                user_.score = user.score
-                user_.rank = await UserDao.get_rank(user.user_id, user.guild_id)
-                users_response.append(user_)
-        return users_response
-
-    @jd4h.command()
-    async def leaderboard(self, ctx) -> None:
-        """Show game leaderboard."""
-        await ctx.defer()  # Defer the response to allow for longer processing time
-        if not ctx.guild:
-            return
-
-        leaderboard = await UserDao.get_leaderboard(ctx.guild.id, 10)
-
-        if not leaderboard:
-            await ctx.respond("No users found in the leaderboard.")
-            return
-        leaderboard_user = await self.get_user_data(leaderboard)
-        generated_leaderboard = (
-            await self.leaderboard_generator.generate_leaderboard(
-                leaderboard_user
-            )
-        )
-        buffer = BytesIO()
-        generated_leaderboard.save(buffer, format="PNG")
-        buffer.seek(0)  # Move to the beginning of the BytesIO buffer
-        file = discord.File(fp=buffer, filename="leaderboard.png")
-
-        await ctx.respond(file=file)
 
     @jd4h.command()
     async def score(self, ctx, member: discord.Member | None = None) -> None:

--- a/commands/cogs/jd4h_leaderboard.py
+++ b/commands/cogs/jd4h_leaderboard.py
@@ -1,0 +1,58 @@
+from io import BytesIO
+
+import discord
+from discord.ext import commands
+
+from config import LOGGER
+from utils import get_or_fetch_user
+from utils.database.dao.users import UserDao
+from utils.image_generator import LeaderboardGenerator, LeaderboardUser
+
+
+class JD4HLeaderboard(commands.Cog):
+    def __init__(self, bot: discord.Bot):
+        self.bot = bot
+        self.leaderboard_generator = LeaderboardGenerator()
+
+    @commands.slash_command(
+        name="jd4h-leaderboard",
+        description="Show JD4H leaderboard",
+    )
+    async def jd4h_leaderboard(self, ctx: discord.ApplicationContext) -> None:
+        """Show JD4H leaderboard."""
+        await ctx.defer()
+        if ctx.guild is None:
+            await ctx.respond("This command can only be used in a server!")
+            return
+
+        leaderboard = await UserDao.get_leaderboard(ctx.guild.id, 10)
+
+        if not leaderboard:
+            await ctx.respond("No users found in the leaderboard.")
+            return
+
+        users: list[LeaderboardUser] = []
+        for user in leaderboard:
+            user_data = await get_or_fetch_user(self.bot, user.user_id)
+            if user_data is None:
+                continue
+            user_ = LeaderboardUser()
+            user_.user = user_data
+            user_.score = str(user.score)
+            user_.rank = await UserDao.get_rank(user.user_id, user.guild_id)
+            users.append(user_)
+
+        generated_leaderboard = (
+            await self.leaderboard_generator.generate_leaderboard(users)
+        )
+        buffer = BytesIO()
+        generated_leaderboard.save(buffer, format="PNG")
+        buffer.seek(0)
+        file = discord.File(fp=buffer, filename="leaderboard.png")
+
+        await ctx.respond(file=file)
+
+
+def setup(bot):
+    bot.add_cog(JD4HLeaderboard(bot))
+    LOGGER.info("JD4HLeaderboard cog loaded")

--- a/utils/image_generator.py
+++ b/utils/image_generator.py
@@ -10,7 +10,7 @@ from config import LOGGER
 class LeaderboardUser:
     user: discord.User
     score: str
-    tirage: str
+    tirage: str = ""
     rank: int
 
 


### PR DESCRIPTION
**Bugfix** : `LeaderboardUser.tirage` a maintenant une valeur par défaut `""`, ce qui évite l'AttributeError sur les commandes qui n'utilisent pas de tirage (comme `/jd4h leaderboard`).

**Séparation** : nouvelle commande standalone `/jd4h-leaderboard` publique, comme pour rngdle. Suppression de `leaderboard` du groupe `/jd4h`.